### PR TITLE
no longer check if on change is stored

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-rrule-builder-ts",
-  "version": "0.0.16",
+  "version": "0.0.18",
   "description": "rrule component for react with mui",
   "main": "index.js",
   "scripts": {

--- a/src/components/RRuleBuilder/RRuleBuilder.tsx
+++ b/src/components/RRuleBuilder/RRuleBuilder.tsx
@@ -58,15 +58,12 @@ const RRuleBuilder = <TDate,>({
   // dense = false,
 }: RRuleBuilderProps<TDate>) => {
   const {
-    // TODO Implement validation errors on date picker
-    // validationErrors,
     startDate,
     setStartDate,
     frequency,
     setFrequency,
     setOnChange,
     setStoreFromRRuleString,
-    onChange: onChangeStored,
     setAdapter,
   } = useBuilderStore();
 
@@ -109,7 +106,7 @@ const RRuleBuilder = <TDate,>({
     }
 
     // store the users onChange function if it exists and is not already stored
-    if (onChange && !onChangeStored) {
+    if (onChange) {
       setOnChange(onChange);
     }
 


### PR DESCRIPTION
- when passing memo based such as useCallback this can cause onchange to become out of sync, always set on re-init of component